### PR TITLE
don't fail if host details or subs can't be fetched

### DIFF
--- a/sat6Inventory.py
+++ b/sat6Inventory.py
@@ -422,15 +422,21 @@ for system in systemdata:
     try:
         base64string = base64.encodestring('%s:%s' % (login, password)).strip()
 
-        sysinfo = urllib2.Request(sysdetailedurl)
-        sysinfo.add_header("Authorization", "Basic %s" % base64string)
-        sysresult = urllib2.urlopen(sysinfo)
-        sysdata = json.load(sysresult)
+        try:
+            sysinfo = urllib2.Request(sysdetailedurl)
+            sysinfo.add_header("Authorization", "Basic %s" % base64string)
+            sysresult = urllib2.urlopen(sysinfo)
+            sysdata = json.load(sysresult)
+        except urllib2.HTTPError:
+            sysdata = system
 
-        subinfo = urllib2.Request(subdetailedurl)
-        subinfo.add_header("Authorization", "Basic %s" % base64string)
-        subresult = urllib2.urlopen(subinfo)
-        subdata = json.load(subresult)
+        try:
+            subinfo = urllib2.Request(subdetailedurl)
+            subinfo.add_header("Authorization", "Basic %s" % base64string)
+            subresult = urllib2.urlopen(subinfo)
+            subdata = json.load(subresult)
+        except urllib2.HTTPError:
+            subdata = {'results': []}
 
         if 'type' in sysdata and sysdata['type'] != 'Hypervisor':
             # skip fetching facts for Hypervisors, they do not submit them anyways


### PR DESCRIPTION
1/ happens when you have a "broken" host (and that happens), in this case we just use the minimal data we got from the search.

2/ happens when the host actually has no subscriptions (like a foreman-only host)