### PR TITLE
try to fetch list of hosts w/o details

### DIFF
--- a/sat6Inventory.py
+++ b/sat6Inventory.py
@@ -314,7 +314,7 @@ try:
     per_page = 100
     while (page == 0 or int(jsonresult['per_page']) == len(jsonresult['results'])):
         page += 1
-        q = [('page', page), ('per_page', per_page)]
+        q = [('page', page), ('per_page', per_page), ('thin', '1')]
         if options.search:
             q.append(('search', options.search))
         if api_version == 2:


### PR DESCRIPTION
In http://projects.theforeman.org/issues/20072 a new param was added:
 thin
It allows to fetch a list of hosts w/o details, which makes fetching a
lot faster. And we need to fetch the full details later anyways.

Poor mans benchmark with about 100 hosts and patched Satellite:
sat6inventory runs 3:00min without the patch, 2:40min with the patch